### PR TITLE
fix: 开屏部分素材快速连点跳过多次回调onAdDismiss

### DIFF
--- a/android/src/main/kotlin/net/niuxiaoer/flutter_gromore/view/FlutterGromoreSplash.kt
+++ b/android/src/main/kotlin/net/niuxiaoer/flutter_gromore/view/FlutterGromoreSplash.kt
@@ -139,6 +139,7 @@ class FlutterGromoreSplash : AppCompatActivity(), GMSplashAdListener, GMSplashAd
     // 发送事件
     private fun sendEvent(msg: String) = AdEventHandler.getInstance().sendEvent(AdEvent(id, msg))
 
+    @Synchronized
     private fun finishActivity() {
         if (closed) {
             return
@@ -147,6 +148,7 @@ class FlutterGromoreSplash : AppCompatActivity(), GMSplashAdListener, GMSplashAd
         closed = true
 
         Utils.splashResult?.success(true);
+        Utils.splashResult = null;
         sendEvent("onAdEnd")
 
         finish()


### PR DESCRIPTION
<img width="787" alt="image" src="https://user-images.githubusercontent.com/33146742/211698256-a68587b4-ccf1-4a02-ad61-b5c7c1b3e73e.png">
多次调用FlutterResult